### PR TITLE
Navigation Improvements

### DIFF
--- a/common/src/main/resources/data/settlements/behavior/fae/go_to.json5
+++ b/common/src/main/resources/data/settlements/behavior/fae/go_to.json5
@@ -17,10 +17,15 @@
         },
         // Else, create a path
         else: {
-          sequence: [
-            // TODO: Show feedback if no path can be found
-            "create_nav_path_to(target=$target)",
-            "move_along_current_path",
+          selector: [
+            {
+              sequence: [
+                // TODO: Show feedback if no path can be found
+                "create_nav_path_to(target=$target)",
+                "move_along_current_path",
+              ]
+            },
+            "remove(key=$target)"
           ],
         },
       },

--- a/common/src/main/resources/data/settlements/behavior/fae/satisfy_resource_from_block.json5
+++ b/common/src/main/resources/data/settlements/behavior/fae/satisfy_resource_from_block.json5
@@ -7,7 +7,7 @@
         then: {
           sequence: [
             // TODO: Account for partial stacks of $item
-            "target_nearest_stockpile_with(item=air)",
+            "target_nearest_stockpile_with(item=minecraft:air)",
             "go_to_target",
             "transfer_item_to_target_until(item=$item, amount=$max)",
           ]

--- a/common/src/main/scala/io/github/jugbot/ai/tree/FaeBehaviorTree.scala
+++ b/common/src/main/scala/io/github/jugbot/ai/tree/FaeBehaviorTree.scala
@@ -41,6 +41,7 @@ object FaeBehavior {
   /// Blackboard functions
   case class set(key: String, value: String) extends FaeBehavior
   case class has(value: String) extends FaeBehavior
+  case class remove(key: String) extends FaeBehavior
   case class add(key: String, value: String) extends FaeBehavior
 
   case class sleep() extends FaeBehavior

--- a/common/src/main/scala/io/github/jugbot/entity/FaeEntity.scala
+++ b/common/src/main/scala/io/github/jugbot/entity/FaeEntity.scala
@@ -411,7 +411,7 @@ class FaeEntity(entityType: EntityType[FaeEntity], world: Level)
           .orElse(
             BlockPos
               .randomInCube(
-                FaeEntity.RANDOM,
+                this.random,
                 FaeEntity.BRUTE_FORCE_SEARCH_ATTEMPTS,
                 this.blockPosition,
                 FaeEntity.BRUTE_FORCE_SEARCH_RADIUS
@@ -429,8 +429,6 @@ object FaeEntity {
   private val NAVIGATION_PROXIMITY = 1
   private val BRUTE_FORCE_SEARCH_RADIUS = 12
   private val BRUTE_FORCE_SEARCH_ATTEMPTS = 20
-  private val RANDOM =
-    RandomSource.create()
 
   final val TYPE: Supplier[EntityType[FaeEntity]] = Suppliers.memoize(() =>
     EntityType.Builder


### PR DESCRIPTION
- [x] Fixes settler navigation getting stuck on bad targets, e.g. if the closest block is targeted but it is unnavigable the settler would be stuck repeatedly trying to path find instead of getting a new target. 
  - Ideally we could target the nearest **navigable** target but that would be prohibitively expensive.
  - After unable to nav to a target, the next tick the targeting will instead use a random selection instead of nearest
- [ ] Prevent settlers from pathfinding outside the range of other important targets e.g. beds, stockpiles
  - Requires #6